### PR TITLE
Allow `init` to be called more than once

### DIFF
--- a/src/BioformatsLoader.jl
+++ b/src/BioformatsLoader.jl
@@ -232,11 +232,19 @@ end
 
 get_bf_path() = joinpath(dirname(@__DIR__), "deps", "bioformats_package.jar")
 
-function init(;memory=1024::Int,log_level::String="ERROR")
-    bfpkg_path = get_bf_path()
-    JavaCall.init(["-ea", "-Xmx$(memory)M", "-Djava.class.path=$bfpkg_path"])
-    enableLogging(log_level) || @warn "Could not enable logging."
-    nothing
+let initialized = Ref(false)
+    global init
+    function init(;memory=1024::Int,log_level::String="ERROR")
+        if !initialized[]
+            bfpkg_path = get_bf_path()
+            JavaCall.init(["-ea", "-Xmx$(memory)M", "-Djava.class.path=$bfpkg_path"])
+            enableLogging(log_level) || @warn "Could not enable logging."
+            initialized[] = true
+        else
+            @warn "BioformatsLoader already initialized"
+        end
+        nothing
+    end
 end
 
 end


### PR DESCRIPTION
Calling `init` a second time currently results in an error.
This prevents one from re-running the tests after fixing a bug.
This makes it safe it call `init` again; it does't do anything other
than warn the user that the library is already intialized.

Even better might be to make it unnecessary to call `init` at all.
This would be possible from inside an `__init__` function,
but that would prevent you from passing kwargs to `init`.