### PR TITLE
Revise initialization procedure, make BioformatsLoader.init() optional

### DIFF
--- a/src/BioformatsLoader.jl
+++ b/src/BioformatsLoader.jl
@@ -237,7 +237,7 @@ function set_memory(memory=1024)
     if memory > 0
         # There should be a distinct memory option in JavaCall
         # Find other memory options and delete them
-        filter!(!startswith("-Xmx"), JavaCall.opts)
+        filter!(opt -> !startswith(opt, "-Xmx"), JavaCall.opts)
         # Add a new option as specified
         JavaCall.addOpts("-Xmx$(memory)M")
     end

--- a/src/BioformatsLoader.jl
+++ b/src/BioformatsLoader.jl
@@ -237,11 +237,7 @@ function set_memory(memory=1024)
     if memory > 0
         # There should be a distinct memory option in JavaCall
         # Find other memory options and delete them
-        for opt in JavaCall.opts
-            if startswith(opt, "-Xmx")
-                delete!(JavaCall.opts, opt)
-            end
-        end
+        filter!(!startswith("-Xmx"), JavaCall.opts)
         # Add a new option as specified
         JavaCall.addOpts("-Xmx$(memory)M")
     end

--- a/src/BioformatsLoader.jl
+++ b/src/BioformatsLoader.jl
@@ -242,7 +242,7 @@ function __init__()
 end
 
 let initialized = Ref(false)
-    global init
+    global init, ensure_init
     function init(;memory=1024::Int,log_level::String="ERROR")
         if !initialized[]
             if !JavaCall.isloaded()
@@ -259,6 +259,7 @@ let initialized = Ref(false)
         end
         nothing
     end
+    ensure_init() = initialized[] ? nothing : init()
 end
 
 end

--- a/src/omexmlreader.jl
+++ b/src/omexmlreader.jl
@@ -19,6 +19,8 @@ struct OMEXMLReader
     meta::JavaObject
 
     function OMEXMLReader()
+        # Make sure JavaCall and logger have been initialized
+        ensure_init()
         service = create_service("loci.formats.services.OMEXMLService")
         meta = jcall(service, "createOMEXMLMetadata", JOMEXMLMetadata, ())
         reader = convert(JIFormatReader, JImageReader(()))


### PR DESCRIPTION
This revises the initialization procedure such that configuration is done in `__init__` and `BioformatsLoader.init` [does not need to be explicitly invoked by an end user](https://github.com/ahnlabb/BioformatsLoader.jl/issues/18#issuecomment-915085247) as requested by @timholy.

Most of the configuration of JavaCall is now done in `__init__` upon `using BioformatsLoader`. The configuration is done using `JavaCall.addOpts` and `JavaCall.addClassPath`. A `set_memory` method is added to aid in setting the `-Xmx` option. It searches for existing options added to JavaCall, removes them, and then adds the new memory option. Together this means JavaCall is configured after `using BioformatsLoader` and gives the end user the opportunity to revise JavaCall's configuration before JVM initialization. Importantly, this allows other packages that use JavaCall to add their own configuration options, allowing more than one Java-based package to be used.

`JavaCall.isloaded()` is checked before calling `JavaCall.init()`. A warning is emitted if JavaCall has already been initialized. The internal check for BioformatsLoader initialization is retained since this includes initialization of the logger.

An `ensure_init()` method is added which only calls `init` if not `initialized`.

`ensure_init()` is added to the `OMEXMLReader` constructor. All methods which use Java seem to either require an existing `OMEXMLReader` or create one, so this is the only place this check is needed. With this change, the user doesn't "have to mess with remembering to call init."

No change in the default options or behavior of the package is expected other than `BioformatsLoader.init()` now being optional.
